### PR TITLE
NXNMhPIR/2486-how-to-provide-mock-data-to-the-provider_2

### DIFF
--- a/lib/components/Provider/index.tsx
+++ b/lib/components/Provider/index.tsx
@@ -50,7 +50,6 @@ export type Context = {
     }[]
   ) => void;
   getClient: () => typeof NotificationAPIClientSDK;
-  addNotificationsToState: (notis: InAppNotification[]) => void;
 };
 
 export const NotificationAPIContext = createContext<Context | undefined>(
@@ -370,8 +369,7 @@ export const NotificationAPIProvider: React.FunctionComponent<
     markAsClicked,
     updateDelivery,
     updateDeliveries,
-    getClient: () => client,
-    addNotificationsToState
+    getClient: () => client
   };
 
   return (

--- a/lib/components/Provider/index.tsx
+++ b/lib/components/Provider/index.tsx
@@ -50,6 +50,7 @@ export type Context = {
     }[]
   ) => void;
   getClient: () => typeof NotificationAPIClientSDK;
+  addNotificationsToState: (notis: InAppNotification[]) => void;
 };
 
 export const NotificationAPIContext = createContext<Context | undefined>(
@@ -72,6 +73,7 @@ type Props = (
   initialLoadMaxAge?: Date;
   playSoundOnNewNotification?: boolean;
   newNotificationSoundPath?: string;
+  client?: typeof NotificationAPIClientSDK;
 };
 
 export const NotificationAPIProvider: React.FunctionComponent<
@@ -132,15 +134,17 @@ export const NotificationAPIProvider: React.FunctionComponent<
   }, []);
 
   const client = useMemo(() => {
-    const client = NotificationAPIClientSDK.init({
-      clientId: config.clientId,
-      userId: config.user.id,
-      hashedUserId: config.hashedUserId,
-      onNewInAppNotifications: (notifications) => {
-        playSound();
-        addNotificationsToState(notifications);
-      }
-    });
+    const client = props.client
+      ? props.client
+      : NotificationAPIClientSDK.init({
+          clientId: config.clientId,
+          userId: config.user.id,
+          hashedUserId: config.hashedUserId,
+          onNewInAppNotifications: (notifications) => {
+            playSound();
+            addNotificationsToState(notifications);
+          }
+        });
 
     //  identify user
     client.identify({
@@ -156,7 +160,8 @@ export const NotificationAPIProvider: React.FunctionComponent<
     config.user.number,
     config.hashedUserId,
     addNotificationsToState,
-    playSound
+    playSound,
+    props.client
   ]);
 
   // Notificaiton loading and state updates
@@ -365,7 +370,8 @@ export const NotificationAPIProvider: React.FunctionComponent<
     markAsClicked,
     updateDelivery,
     updateDeliveries,
-    getClient: () => client
+    getClient: () => client,
+    addNotificationsToState
   };
 
   return (

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@notificationapi/react",
   "private": false,
-  "version": "0.0.32",
+  "version": "0.0.33",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import LiveConnections from './LiveComponents';
 import MockedComponents from './MockedComponents';
 
 function App() {
-  const [isMocked, setIsMocked] = React.useState(true);
+  const [isMocked, setIsMocked] = React.useState(false);
 
   return (
     <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,15 +4,14 @@ import LiveConnections from './LiveComponents';
 import MockedComponents from './MockedComponents';
 
 function App() {
-  const [isLiveMode, setIsLiveMode] = React.useState(true);
+  const [isMocked, setIsMocked] = React.useState(true);
 
   return (
     <>
-      <Button onClick={() => setIsLiveMode(!isLiveMode)}>
-        {isLiveMode ? '🔴' : '🟢'} Switch to {isLiveMode ? 'Mocked' : 'Live'}{' '}
-        Mode
+      <Button onClick={() => setIsMocked(!isMocked)}>
+        {isMocked ? '🟢' : '🔴'} Switch to {isMocked ? 'Live' : 'Mocked'} Mode
       </Button>
-      {isLiveMode ? <LiveConnections /> : <MockedComponents />}
+      {isMocked ? <MockedComponents /> : <LiveConnections />}
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,81 +1,19 @@
 import React from 'react';
-import { Button, Divider } from 'antd';
-import {
-  NotificationFeed,
-  NotificationPopup,
-  NotificationLauncher,
-  NotificationCounter,
-  NotificationAPIProvider,
-  NotificationPreferencesPopup,
-  NotificationPreferencesInline
-} from '../lib/main';
-import { MyButton } from './MyButton';
+import { Button } from 'antd';
+import LiveConnections from './LiveComponents';
+import MockedComponents from './MockedComponents';
 
 function App() {
-  const [preferencesPopupVisibility, setPreferencesPopupVisiblity] =
-    React.useState(false);
+  const [isLiveMode, setIsLiveMode] = React.useState(true);
 
   return (
-    <div
-      style={{
-        height: '200vh',
-        background: '#f0f2f5',
-        padding: 24
-      }}
-    >
-      <NotificationAPIProvider
-        clientId="24nojpnrsdc53fkslha0roov05"
-        user={{
-          id: 'sahand',
-          email: 'sahand.seifi@gmail.com'
-        }}
-      >
-        <h2>Popup:</h2>
-        <NotificationPopup />
-
-        <Divider />
-
-        <h2>Launcher:</h2>
-        <p>Look at the bottom right :)</p>
-        <NotificationLauncher />
-
-        <Divider />
-
-        <h2>Counter (Standalone)</h2>
-        <NotificationCounter />
-
-        <Divider />
-
-        <h2>Counter on an element</h2>
-        <NotificationCounter
-          count={(n) => {
-            return n.notificationId === 'conversion_failure' && !n.archived;
-          }}
-        >
-          <MyButton />
-        </NotificationCounter>
-
-        <Divider />
-
-        <h2>Feed:</h2>
-        <NotificationFeed infiniteScrollHeight={300} />
-
-        <Divider />
-        <h2>Preferences Popup:</h2>
-        <Button onClick={() => setPreferencesPopupVisiblity(true)}>
-          Preferences Popup
-        </Button>
-        <NotificationPreferencesPopup
-          open={preferencesPopupVisibility}
-          onClose={() => {
-            setPreferencesPopupVisiblity(false);
-          }}
-        />
-
-        <h2>Preferences Inline:</h2>
-        <NotificationPreferencesInline />
-      </NotificationAPIProvider>
-    </div>
+    <>
+      <Button onClick={() => setIsLiveMode(!isLiveMode)}>
+        {isLiveMode ? '🔴' : '🟢'} Switch to {isLiveMode ? 'Mocked' : 'Live'}{' '}
+        Mode
+      </Button>
+      {isLiveMode ? <LiveConnections /> : <MockedComponents />}
+    </>
   );
 }
 

--- a/src/FakeNotification.tsx
+++ b/src/FakeNotification.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Button, Form, Input } from 'antd';
+import { NotificationAPIProvider } from '../lib/main';
+import { InAppNotification } from '@notificationapi/core/dist/interfaces';
+
+export const FakeNotification: React.FC = () => {
+  const notificationapi = NotificationAPIProvider.useNotificationAPIContext();
+  const [form] = Form.useForm();
+  const onFinish = (
+    values: Omit<InAppNotification, 'id' | 'notificationId' | 'seen' | 'date'>
+  ) => {
+    const notification: InAppNotification = {
+      ...values,
+      date: new Date().toISOString(),
+      seen: false,
+      id: Math.random().toString(36).substr(2, 9),
+      notificationId: Math.random().toString(36).substr(2, 9),
+      template: {
+        instant: {
+          title: values.title,
+          redirectURL: 'https://notificationapi.com',
+          imageURL: 'https://via.placeholder.com/150'
+        },
+        batch: {
+          title: values.title,
+          redirectURL: 'https://notificationapi.com',
+          imageURL: 'https://via.placeholder.com/150'
+        }
+      }
+    };
+    notification.title = values.title ?? 'My fake notification';
+    notificationapi.addNotificationsToState([notification]);
+  };
+
+  return (
+    <Form
+      form={form}
+      onFinish={onFinish}
+      layout="vertical"
+      style={{ maxWidth: '800px', margin: '0 auto' }}
+    >
+      <Form.Item
+        name="title"
+        label="Title"
+        // rules={[{ required: true, message: 'Please input the title!' }]}
+      >
+        <Input placeholder="My fake notification" />
+      </Form.Item>
+
+      <Button type="primary" htmlType="submit" style={{ width: '100%' }}>
+        Generate a Fake Notification
+      </Button>
+    </Form>
+  );
+};

--- a/src/FakeNotification.tsx
+++ b/src/FakeNotification.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Button, Form, Input } from 'antd';
-import { NotificationAPIProvider } from '../lib/main';
 import { InAppNotification } from '@notificationapi/core/dist/interfaces';
 
-export const FakeNotification: React.FC = () => {
-  const notificationapi = NotificationAPIProvider.useNotificationAPIContext();
+export const FakeNotification: React.FC<{
+  setNotification: React.Dispatch<React.SetStateAction<InAppNotification[]>>;
+}> = ({ setNotification }) => {
   const [form] = Form.useForm();
   const onFinish = (
     values: Omit<InAppNotification, 'id' | 'notificationId' | 'seen' | 'date'>
@@ -29,7 +29,7 @@ export const FakeNotification: React.FC = () => {
       }
     };
     notification.title = values.title ?? 'My fake notification';
-    notificationapi.addNotificationsToState([notification]);
+    setNotification([notification]);
   };
 
   return (
@@ -42,7 +42,7 @@ export const FakeNotification: React.FC = () => {
       <Form.Item
         name="title"
         label="Title"
-        // rules={[{ required: true, message: 'Please input the title!' }]}
+        rules={[{ required: true, message: 'Please input the title!' }]}
       >
         <Input placeholder="My fake notification" />
       </Form.Item>

--- a/src/LiveComponents.tsx
+++ b/src/LiveComponents.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import {
+  NotificationFeed,
+  NotificationPopup,
+  NotificationLauncher,
+  NotificationCounter,
+  NotificationAPIProvider,
+  NotificationPreferencesPopup,
+  NotificationPreferencesInline
+} from '../lib/main';
+import { Divider, Button } from 'antd';
+import { MyButton } from './MyButton';
+
+const LiveComponents: React.FC = () => {
+  const [preferencesPopupVisibility, setPreferencesPopupVisiblity] =
+    useState(false);
+
+  return (
+    <>
+      <h1 style={{ textAlign: 'center' }}>Live Mode</h1>
+      <h2 style={{ textAlign: 'center' }}>live connection to the server</h2>
+      <div
+        style={{
+          height: '210vh',
+          background: '#e6fffb', // Changed background color to indicate live connection
+          padding: 24
+        }}
+      >
+        <NotificationAPIProvider
+          clientId="24nojpnrsdc53fkslha0roov05"
+          user={{
+            id: 'sahand',
+            email: 'sahand.seifi@gmail.com'
+          }}
+        >
+          <h2>Popup:</h2>
+          <NotificationPopup />
+
+          <Divider />
+
+          <h2>Launcher:</h2>
+          <p>Look at the bottom right :)</p>
+          <NotificationLauncher />
+
+          <Divider />
+
+          <h2>Counter (Standalone)</h2>
+          <NotificationCounter />
+
+          <Divider />
+
+          <h2>Counter on an element</h2>
+          <NotificationCounter
+            count={(n) => {
+              return n.notificationId === 'conversion_failure' && !n.archived;
+            }}
+          >
+            <MyButton />
+          </NotificationCounter>
+
+          <Divider />
+
+          <h2>Feed:</h2>
+          <NotificationFeed infiniteScrollHeight={300} />
+
+          <Divider />
+          <h2>Preferences Popup:</h2>
+          <Button onClick={() => setPreferencesPopupVisiblity(true)}>
+            Preferences Popup
+          </Button>
+          <NotificationPreferencesPopup
+            open={preferencesPopupVisibility}
+            onClose={() => {
+              setPreferencesPopupVisiblity(false);
+            }}
+          />
+
+          <h2>Preferences Inline:</h2>
+          <NotificationPreferencesInline />
+        </NotificationAPIProvider>
+      </div>
+    </>
+  );
+};
+
+export default LiveComponents;

--- a/src/MockedComponents.tsx
+++ b/src/MockedComponents.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import {
+  NotificationFeed,
+  NotificationPopup,
+  NotificationLauncher,
+  NotificationCounter,
+  NotificationAPIProvider,
+  NotificationPreferencesPopup,
+  NotificationPreferencesInline
+} from '../lib/main';
+import { Divider, Button } from 'antd';
+import { MyButton } from './MyButton';
+import { FakeNotification } from './FakeNotification';
+import { mockedClient } from './mockedClient';
+
+const LiveComponents: React.FC = () => {
+  const [preferencesPopupVisibility, setPreferencesPopupVisiblity] =
+    useState(false);
+
+  return (
+    <>
+      <h1 style={{ textAlign: 'center' }}>Mocked:</h1>
+      <h2 style={{ textAlign: 'center' }}>
+        Experience the magic of notifications!
+      </h2>
+      <div
+        style={{
+          height: '210vh',
+          background: '#f0f2f5',
+          padding: 24
+        }}
+      >
+        <NotificationAPIProvider
+          clientId="24nojpnrsdc53fkslha0roov05"
+          user={{
+            id: 'mockedUser',
+            email: 'mockedUser@gmail.com'
+          }}
+          client={mockedClient}
+        >
+          <h3 style={{ textAlign: 'center' }}>
+            Fill out the form below to generate a fake notification and see it
+            in action!
+          </h3>
+          <FakeNotification />
+          <Divider />
+          <h2>Popup:</h2>
+          <NotificationPopup
+            count={(n) => {
+              return !n.archived;
+            }}
+          />
+
+          <Divider />
+
+          <h2>Launcher:</h2>
+          <p>Look at the bottom right :)</p>
+          <NotificationLauncher
+            count={(n) => {
+              return !n.archived;
+            }}
+          />
+
+          <Divider />
+
+          <h2>Counter (Standalone)</h2>
+          <NotificationCounter
+            count={(n) => {
+              return !n.archived;
+            }}
+          />
+
+          <Divider />
+
+          <h2>Counter on an element</h2>
+          <NotificationCounter
+            count={(n) => {
+              return !n.archived;
+            }}
+          >
+            <MyButton />
+          </NotificationCounter>
+          <Divider />
+          <h2>Feed:</h2>
+          <NotificationFeed infiniteScrollHeight={300} />
+
+          <Divider />
+          <h2>Preferences Popup:</h2>
+          <Button onClick={() => setPreferencesPopupVisiblity(true)}>
+            Preferences Popup
+          </Button>
+          <NotificationPreferencesPopup
+            open={preferencesPopupVisibility}
+            onClose={() => {
+              setPreferencesPopupVisiblity(false);
+            }}
+          />
+
+          <h2>Preferences Inline:</h2>
+          <NotificationPreferencesInline />
+        </NotificationAPIProvider>
+      </div>
+    </>
+  );
+};
+
+export default LiveComponents;

--- a/src/MockedComponents.tsx
+++ b/src/MockedComponents.tsx
@@ -11,12 +11,13 @@ import {
 import { Divider, Button } from 'antd';
 import { MyButton } from './MyButton';
 import { FakeNotification } from './FakeNotification';
-import { mockedClient } from './mockedClient';
+import { InAppNotification } from '@notificationapi/core/dist/interfaces';
+import { getMarkedClient } from './mockedClient';
 
 const LiveComponents: React.FC = () => {
   const [preferencesPopupVisibility, setPreferencesPopupVisiblity] =
     useState(false);
-
+  const [notification, setNotification] = useState<InAppNotification[]>([]);
   return (
     <>
       <h1 style={{ textAlign: 'center' }}>Mocked:</h1>
@@ -31,18 +32,22 @@ const LiveComponents: React.FC = () => {
         }}
       >
         <NotificationAPIProvider
-          clientId="24nojpnrsdc53fkslha0roov05"
+          clientId="24nojpnrc53fkslha0roov05"
           user={{
             id: 'mockedUser',
             email: 'mockedUser@gmail.com'
           }}
-          client={mockedClient}
+          client={getMarkedClient(
+            '24nojpnrsdc53fha0roov05',
+            'mockedUser',
+            notification
+          )}
         >
           <h3 style={{ textAlign: 'center' }}>
             Fill out the form below to generate a fake notification and see it
             in action!
           </h3>
-          <FakeNotification />
+          <FakeNotification setNotification={setNotification} />
           <Divider />
           <h2>Popup:</h2>
           <NotificationPopup

--- a/src/mockedClient.ts
+++ b/src/mockedClient.ts
@@ -66,27 +66,35 @@ export const mockedClient = {
     // Create a mock WebSocket object
     const mockWebSocket = {
       send: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
-        console.log(data);
+        console.log('WebSocket message sent:', data);
       },
       close: (code?: number, reason?: string) => {
-        console.log(code, reason);
+        console.log('WebSocket closed with code:', code, 'and reason:', reason);
       },
       addEventListener: (
         type: string,
         listener: EventListenerOrEventListenerObject,
         options?: boolean | AddEventListenerOptions
       ) => {
-        console.log(type, listener, options);
+        console.log(
+          `Event listener added for type: ${type}`,
+          listener,
+          options
+        );
       },
       removeEventListener: (
         type: string,
         listener: EventListenerOrEventListenerObject,
         options?: boolean | EventListenerOptions
       ) => {
-        console.log(type, listener, options);
+        console.log(
+          `Event listener removed for type: ${type}`,
+          listener,
+          options
+        );
       },
       dispatchEvent: (event: Event) => {
-        console.log(event);
+        console.log('WebSocket event dispatched:', event);
         return true;
       },
       readyState: WebSocket.CONNECTING,
@@ -112,6 +120,7 @@ export const mockedClient = {
       hasMore: false, // Set the actual value here
       oldestReceived: '' // Set the actual value here
     };
+
     return Promise.resolve(response);
   },
   updateInAppNotifications: function () {

--- a/src/mockedClient.ts
+++ b/src/mockedClient.ts
@@ -1,0 +1,135 @@
+import {
+  GetPreferencesResponse,
+  InAppNotification
+} from '@notificationapi/core/dist/interfaces';
+
+export const mockedClient = {
+  config: {
+    host: 'sdfsdddd',
+    websocketHost: 'websocketHost',
+    userId: 'b',
+    clientId: 'a',
+    hashedUserId: '',
+    getInAppDefaultCount: 100,
+    getInAppDefaultOldest: '2024-09-17T23:38:53.878Z',
+    keepWebSocketAliveForSeconds: 86400
+  },
+  rest: {
+    generic: async () => {
+      // Implement the generic method logic here
+      return Promise.resolve({});
+    },
+    getNotifications: async () => {
+      const inAppNotification: InAppNotification[] = [];
+      const response = {
+        notifications: inAppNotification, // Add actual items data here
+        hasMore: false, // Set the actual value here
+        oldestReceived: '' // Set the actual value here
+      };
+      return Promise.resolve(response);
+    },
+    patchNotifications: async () => {
+      // Implement the patchNotifications method logic here
+      return Promise.resolve({});
+    },
+    getPreferences: async () => {
+      // Implement the getPreferences method logic here
+      const response: GetPreferencesResponse = {
+        preferences: [], // Add actual preferences data here
+        notifications: [], // Add actual notifications data here
+        subNotifications: [] // Add actual subNotifications data here
+      };
+      return Promise.resolve(response);
+    },
+    postPreferences: async () => {
+      // Implement the postPreferences method logic here
+      return Promise.resolve({});
+    },
+    postUser: async () => {
+      // Implement the postUser method logic here
+      return Promise.resolve({});
+    }
+  },
+  init: function () {
+    throw new Error('Function not implemented.');
+  },
+  websocket: {
+    object: undefined,
+    connect: function (): WebSocket {
+      throw new Error('Function not implemented.');
+    },
+    disconnect: function (): void {
+      throw new Error('Function not implemented.');
+    }
+  },
+  openWebSocket: function (): WebSocket {
+    // Create a mock WebSocket object
+    const mockWebSocket = {
+      send: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
+        console.log(data);
+      },
+      close: (code?: number, reason?: string) => {
+        console.log(code, reason);
+      },
+      addEventListener: (
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions
+      ) => {
+        console.log(type, listener, options);
+      },
+      removeEventListener: (
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions
+      ) => {
+        console.log(type, listener, options);
+      },
+      dispatchEvent: (event: Event) => {
+        console.log(event);
+        return true;
+      },
+      readyState: WebSocket.CONNECTING,
+      bufferedAmount: 0,
+      extensions: '',
+      protocol: '',
+      binaryType: 'blob',
+      onopen: null,
+      onerror: null,
+      onclose: null,
+      onmessage: null
+    } as WebSocket;
+
+    return mockWebSocket;
+  },
+  getInAppNotifications: function (): Promise<{
+    items: InAppNotification[];
+    hasMore: boolean;
+    oldestReceived: string;
+  }> {
+    const response = {
+      items: [], // Add actual items data here
+      hasMore: false, // Set the actual value here
+      oldestReceived: '' // Set the actual value here
+    };
+    return Promise.resolve(response);
+  },
+  updateInAppNotifications: function () {
+    return Promise.resolve({});
+  },
+  updateDeliveryOption: function (): Promise<void> {
+    throw new Error('Function not implemented.');
+  },
+  getPreferences: async () => {
+    // Implement the getPreferences method logic here
+    const response: GetPreferencesResponse = {
+      preferences: [], // Add actual preferences data here
+      notifications: [], // Add actual notifications data here
+      subNotifications: [] // Add actual subNotifications data here
+    };
+    return Promise.resolve(response);
+  },
+  identify: function (): Promise<void> {
+    return Promise.resolve();
+  }
+};

--- a/src/mockedClient.ts
+++ b/src/mockedClient.ts
@@ -1,35 +1,37 @@
+import { NotificationAPIClientSDK } from '@notificationapi/core';
 import {
   GetPreferencesResponse,
   InAppNotification
 } from '@notificationapi/core/dist/interfaces';
 
-export const mockedClient = {
-  config: {
-    host: 'sdfsdddd',
-    websocketHost: 'websocketHost',
-    userId: 'b',
-    clientId: 'a',
-    hashedUserId: '',
-    getInAppDefaultCount: 100,
-    getInAppDefaultOldest: '2024-09-17T23:38:53.878Z',
-    keepWebSocketAliveForSeconds: 86400
-  },
-  rest: {
-    generic: async () => {
-      // Implement the generic method logic here
-      return Promise.resolve({});
+export const getMarkedClient = (
+  clientId: string,
+  userId: string,
+  inAppNotification: InAppNotification[]
+): typeof NotificationAPIClientSDK => {
+  const client: typeof NotificationAPIClientSDK = NotificationAPIClientSDK.init(
+    {
+      clientId,
+      userId
+    }
+  );
+  const mockedClient: typeof NotificationAPIClientSDK = {
+    ...client,
+    websocket: {
+      object: undefined,
+      connect: function (): WebSocket {
+        console.log('connect method called');
+        throw new Error('Function not implemented.');
+      },
+      disconnect: function (): void {
+        console.log('disconnect method called');
+        throw new Error('Function not implemented.');
+      }
     },
-    getNotifications: async () => {
-      const inAppNotification: InAppNotification[] = [];
-      const response = {
-        notifications: inAppNotification, // Add actual items data here
-        hasMore: false, // Set the actual value here
-        oldestReceived: '' // Set the actual value here
-      };
-      return Promise.resolve(response);
+    openWebSocket: function (): WebSocket {
+      return {} as WebSocket;
     },
-    patchNotifications: async () => {
-      // Implement the patchNotifications method logic here
+    updateInAppNotifications: function () {
       return Promise.resolve({});
     },
     getPreferences: async () => {
@@ -41,95 +43,19 @@ export const mockedClient = {
       };
       return Promise.resolve(response);
     },
-    postPreferences: async () => {
-      // Implement the postPreferences method logic here
-      return Promise.resolve({});
-    },
-    postUser: async () => {
-      // Implement the postUser method logic here
-      return Promise.resolve({});
+    identify: function (): Promise<void> {
+      return Promise.resolve();
     }
-  },
-  init: function () {
-    throw new Error('Function not implemented.');
-  },
-  websocket: {
-    object: undefined,
-    connect: function (): WebSocket {
-      throw new Error('Function not implemented.');
-    },
-    disconnect: function (): void {
-      throw new Error('Function not implemented.');
-    }
-  },
-  openWebSocket: function (): WebSocket {
-    // Create a mock WebSocket object
-    const mockWebSocket = {
-      send: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
-        console.log('WebSocket message sent:', data);
-      },
-      close: (code?: number, reason?: string) => {
-        console.log('WebSocket closed with code:', code, 'and reason:', reason);
-      },
-      addEventListener: (
-        type: string,
-        listener: EventListenerOrEventListenerObject,
-        options?: boolean | AddEventListenerOptions
-      ) => {
-        console.log(
-          `Event listener added for type: ${type}`,
-          listener,
-          options
-        );
-      },
-      removeEventListener: (
-        type: string,
-        listener: EventListenerOrEventListenerObject,
-        options?: boolean | EventListenerOptions
-      ) => {
-        console.log(
-          `Event listener removed for type: ${type}`,
-          listener,
-          options
-        );
-      },
-      dispatchEvent: (event: Event) => {
-        console.log('WebSocket event dispatched:', event);
-        return true;
-      },
-      readyState: WebSocket.CONNECTING,
-      bufferedAmount: 0,
-      extensions: '',
-      protocol: '',
-      binaryType: 'blob',
-      onopen: null,
-      onerror: null,
-      onclose: null,
-      onmessage: null
-    } as WebSocket;
-
-    return mockWebSocket;
-  },
-  getInAppNotifications: function (): Promise<{
-    items: InAppNotification[];
-    hasMore: boolean;
-    oldestReceived: string;
-  }> {
+  };
+  mockedClient.rest.getNotifications = async () => {
     const response = {
-      items: [], // Add actual items data here
+      notifications: inAppNotification, // Add actual items data here
       hasMore: false, // Set the actual value here
       oldestReceived: '' // Set the actual value here
     };
-
     return Promise.resolve(response);
-  },
-  updateInAppNotifications: function () {
-    return Promise.resolve({});
-  },
-  updateDeliveryOption: function (): Promise<void> {
-    throw new Error('Function not implemented.');
-  },
-  getPreferences: async () => {
+  };
+  mockedClient.rest.getPreferences = async () => {
     // Implement the getPreferences method logic here
     const response: GetPreferencesResponse = {
       preferences: [], // Add actual preferences data here
@@ -137,8 +63,6 @@ export const mockedClient = {
       subNotifications: [] // Add actual subNotifications data here
     };
     return Promise.resolve(response);
-  },
-  identify: function (): Promise<void> {
-    return Promise.resolve();
-  }
+  };
+  return mockedClient;
 };


### PR DESCRIPTION
Accepting the client as an optional props so you can define you own client. 
A sample of a mocked client is added 
you can see the components in both live and mocked 