### PR TITLE
Refactor web push subscription logic in Provider component

### DIFF
--- a/lib/components/Provider/index.tsx
+++ b/lib/components/Provider/index.tsx
@@ -390,34 +390,36 @@ export const NotificationAPIProvider: React.FunctionComponent<
         .register(config.customServiceWorkerPath)
         .then(async (registration) => {
           setWebPushOptInMessage(false);
-          Notification.requestPermission().then(async (permission) => {
-            if (permission === 'granted') {
-              await registration.pushManager
-                .subscribe({
-                  userVisibleOnly: true,
-                  applicationServerKey:
-                    userAccountMetaData?.userAccountMetadata
-                      .environmentVapidPublicKey
-                })
-                .then(async (res) => {
-                  const body = {
-                    webPushTokens: [
-                      {
-                        sub: {
-                          endpoint: res.toJSON().endpoint as string,
-                          keys: res.toJSON().keys as PushSubscription['keys']
+          if ('Notification' in window) {
+            Notification.requestPermission().then(async (permission) => {
+              if (permission === 'granted') {
+                await registration.pushManager
+                  .subscribe({
+                    userVisibleOnly: true,
+                    applicationServerKey:
+                      userAccountMetaData?.userAccountMetadata
+                        .environmentVapidPublicKey
+                  })
+                  .then(async (res) => {
+                    const body = {
+                      webPushTokens: [
+                        {
+                          sub: {
+                            endpoint: res.toJSON().endpoint as string,
+                            keys: res.toJSON().keys as PushSubscription['keys']
+                          }
                         }
-                      }
-                    ]
-                  };
-                  await client.identify(body);
-                  console.log('index');
-                  localStorage.setItem('hideWebPushOptInMessage', 'true');
-                });
-            } else if (permission === 'denied') {
-              console.log('Permission for notifications was denied');
-            }
-          });
+                      ]
+                    };
+                    await client.identify(body);
+                    console.log('index');
+                    localStorage.setItem('hideWebPushOptInMessage', 'true');
+                  });
+              } else if (permission === 'denied') {
+                console.log('Permission for notifications was denied');
+              }
+            });
+          }
         })
         .catch((e) => {
           if (e.code === 18) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@notificationapi/react",
   "private": false,
-  "version": "0.0.35",
+  "version": "0.0.36",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Refactored the web push subscription logic in the Provider component to avoid using the Notification API if it is not defined in the browser. This ensures that the subscription process is only triggered when the necessary permissions are granted.