### PR TITLE
S1 n2rr1 f/2737 new channels for failure and success GitHub actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,10 +11,10 @@ jobs:
     name: Build & Punlish
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
 

--- a/.github/workflows/push_pipeline.yml
+++ b/.github/workflows/push_pipeline.yml
@@ -58,7 +58,8 @@ jobs:
         env:
           NODE_ENV: production
 
-      - name: Send Slack Notification (Post-Publish)
+      - name: Send Slack Notification on Success
+        if: steps.publish.outputs.type != 'none' && success()
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
@@ -66,5 +67,15 @@ jobs:
           text: Published to NPM ${{ steps.publish.outputs.old-version }} -> ${{ steps.publish.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: steps.publish.outputs.type != 'none' && always()
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SUCCESS_WEBHOOK_URL }}
+
+      - name: Send Slack Notification on Failure
+        if: steps.publish.outputs.type != 'none' && (failure() || cancelled())
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo
+          text: Published to NPM ${{ steps.publish.outputs.old-version }} -> ${{ steps.publish.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_FAILED_WEBHOOK_URL }}

--- a/.github/workflows/push_pipeline.yml
+++ b/.github/workflows/push_pipeline.yml
@@ -13,16 +13,16 @@ jobs:
       releaseType: ${{ steps.publish.outputs.type }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Cache node_modules
         id: cache-modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: 18.17.x-${{ runner.OS }}-build-${{ hashFiles('package.json') }}

--- a/.github/workflows/push_pipeline.yml
+++ b/.github/workflows/push_pipeline.yml
@@ -63,7 +63,7 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          fields: repo
+          fields: repo,message,commit,workflow,took
           text: Published to NPM ${{ steps.publish.outputs.old-version }} -> ${{ steps.publish.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          fields: repo
+          fields: repo,message,commit,workflow,took
           text: Published to NPM ${{ steps.publish.outputs.old-version }} -> ${{ steps.publish.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update Slack notifications and upgrade GitHub actions.
- Change existing GitHub builds Slack notification to send separate notifications for success and failure.
- Update actions to latest versions.