### PR TITLE
4 o8c3 ptu/2948 cleanup react sdk unreadbadge props

### DIFF
--- a/lib/components/Notifications/UnreadBadge.tsx
+++ b/lib/components/Notifications/UnreadBadge.tsx
@@ -19,6 +19,8 @@ export type UnreadBadgeProps = {
     bottom?: number;
     left?: number;
   };
+  fontColor?: string;
+  bubleColor?: string;
 };
 
 export const UnreadBadge: React.FunctionComponent<
@@ -53,7 +55,12 @@ export const UnreadBadge: React.FunctionComponent<
       max={props.max}
       variant={props.dot ? 'dot' : 'standard'}
       showZero={props.showZero}
-      color="error"
+      sx={{
+        '& .MuiBadge-badge': {
+          backgroundColor: props.bubleColor || '#d32f2f',
+          color: props.fontColor || '#FFF'
+        }
+      }}
       slotProps={{
         badge: {
           style: {

--- a/lib/components/Notifications/UnreadBadge.tsx
+++ b/lib/components/Notifications/UnreadBadge.tsx
@@ -20,7 +20,7 @@ export type UnreadBadgeProps = {
     left?: number;
   };
   fontColor?: string;
-  bubleColor?: string;
+  bubbleColor?: string;
 };
 
 export const UnreadBadge: React.FunctionComponent<
@@ -57,7 +57,7 @@ export const UnreadBadge: React.FunctionComponent<
       showZero={props.showZero}
       sx={{
         '& .MuiBadge-badge': {
-          backgroundColor: props.bubleColor || '#d32f2f',
+          backgroundColor: props.bubbleColor || '#d32f2f',
           color: props.fontColor || '#FFF'
         }
       }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@notificationapi/react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@notificationapi/react",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@notificationapi/react",
   "private": false,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
Added the fontColor and bubleColor props to allow users the ability to customize the unread badge to which was available prior with Ant Design.