### PR TITLE
Lq pq w5m s/2951 fix notificationpopup props for height and add popoverposition prop react sdk

### DIFF
--- a/lib/components/Notifications/Inbox.tsx
+++ b/lib/components/Notifications/Inbox.tsx
@@ -142,6 +142,13 @@ export const Inbox: React.FC<InboxProps> = (props) => {
             />
           }
         >
+          {props.pagePosition === 'top' && orderedNotifications.length > 0 && (
+            <Pagination
+              count={Math.ceil(orderedNotifications.length / props.pageSize)}
+              page={page}
+              onChange={handlePageChange}
+            />
+          )}
           {orderedNotifications
             .filter((_n, i) => {
               if (props.pagination === 'PAGINATED') {
@@ -162,13 +169,14 @@ export const Inbox: React.FC<InboxProps> = (props) => {
                 />
               </ListItem>
             ))}
-          {orderedNotifications.length > 0 && (
-            <Pagination
-              count={Math.ceil(orderedNotifications.length / props.pageSize)}
-              page={page}
-              onChange={handlePageChange}
-            />
-          )}
+          {props.pagePosition === 'bottom' &&
+            orderedNotifications.length > 0 && (
+              <Pagination
+                count={Math.ceil(orderedNotifications.length / props.pageSize)}
+                page={page}
+                onChange={handlePageChange}
+              />
+            )}
           {orderedNotifications.length === 0 && emptyComponent}
         </List>
       )}

--- a/lib/components/Notifications/Inbox.tsx
+++ b/lib/components/Notifications/Inbox.tsx
@@ -21,6 +21,7 @@ export type InboxProps = {
     | undefined;
   header?: InboxHeaderProps;
   empty?: React.ReactNode;
+  imageShape?: 'circle' | 'square';
 };
 
 export const Inbox: React.FC<InboxProps> = (props) => {
@@ -127,6 +128,7 @@ export const Inbox: React.FC<InboxProps> = (props) => {
                   notifications={n}
                   markAsClicked={context.markAsClicked}
                   renderer={props.notificationRenderer}
+                  imageShape={props.imageShape}
                 />
               </ListItem>
             )}
@@ -166,6 +168,7 @@ export const Inbox: React.FC<InboxProps> = (props) => {
                   notifications={n}
                   markAsClicked={context.markAsClicked}
                   renderer={props.notificationRenderer}
+                  imageShape={props.imageShape}
                 />
               </ListItem>
             ))}

--- a/lib/components/Notifications/Notification.tsx
+++ b/lib/components/Notifications/Notification.tsx
@@ -38,6 +38,7 @@ export type NotificationProps = {
   markAsArchived: (ids: string[] | 'ALL') => void;
   markAsClicked: (ids: string[]) => void;
   renderer?: (notification: InAppNotification[]) => ReactNode;
+  imageShape?: 'circle' | 'square';
 };
 
 export const Notification = (props: NotificationProps) => {
@@ -110,6 +111,7 @@ export const Notification = (props: NotificationProps) => {
             marginRight: 8,
             marginLeft: 12
           }}
+          variant={props.imageShape === 'circle' ? 'circular' : 'rounded'}
         />
       </div>
 

--- a/lib/components/Notifications/NotificationFeed.tsx
+++ b/lib/components/Notifications/NotificationFeed.tsx
@@ -21,6 +21,7 @@ export type NotificationFeedProps = {
     notification?: NotificationProps['renderer'];
   };
   header?: InboxHeaderProps;
+  imageShape?: 'circle' | 'square';
 };
 
 export const NotificationFeed: React.FC<NotificationFeedProps> = (props) => {
@@ -61,7 +62,8 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = (props) => {
         props.header?.button1ClickHandler ?? context.markAsArchived,
       button2ClickHandler:
         props.header?.button2ClickHandler ?? (() => setOpenPreferences(true))
-    }
+    },
+    imageShape: props.imageShape || 'circle'
   };
 
   return (
@@ -83,6 +85,7 @@ export const NotificationFeed: React.FC<NotificationFeedProps> = (props) => {
         pagePosition={config.pagePosition}
         notificationRenderer={config.renderers.notification}
         header={config.header}
+        imageShape={config.imageShape}
       />
       {context.webPushOptInMessage &&
         localStorage.getItem('hideWebPushOptInMessage') !== 'true' && (

--- a/lib/components/Notifications/NotificationLauncher.tsx
+++ b/lib/components/Notifications/NotificationLauncher.tsx
@@ -65,6 +65,12 @@ export const NotificationLauncher: React.FC<NotificationLaucherProps> = (
     },
     renderers: {
       notification: props.renderers?.notification
+    },
+    popoverPosition: {
+      anchorOrigin: {
+        vertical: props.popoverPosition?.anchorOrigin?.vertical ?? 'top',
+        horizontal: props.popoverPosition?.anchorOrigin?.horizontal ?? 'left'
+      }
     }
   };
 

--- a/lib/components/Notifications/NotificationPopup.tsx
+++ b/lib/components/Notifications/NotificationPopup.tsx
@@ -29,6 +29,12 @@ export type NotificationPopupProps = {
     notification?: NotificationProps['renderer'];
   };
   header?: InboxHeaderProps;
+  popoverPosition?: {
+    anchorOrigin?: {
+      vertical: 'top' | 'center' | 'bottom';
+      horizontal: 'left' | 'center' | 'right';
+    };
+  };
 };
 
 export const NotificationPopup: React.FC<NotificationPopupProps> = (props) => {
@@ -60,7 +66,7 @@ export const NotificationPopup: React.FC<NotificationPopupProps> = (props) => {
     iconColor: props.iconColor || '#000000',
     pagination: props.pagination || 'INFINITE_SCROLL',
     pageSize: props.pageSize || 10,
-    pagePosition: props.pagePosition || 'top',
+    pagePosition: props.pagePosition || 'bottom',
     popupZIndex: props.popupZIndex || 1030,
     unreadBadgeProps: props.unreadBadgeProps ?? {},
     count: props.count || 'COUNT_UNOPENED_NOTIFICATIONS',
@@ -74,6 +80,12 @@ export const NotificationPopup: React.FC<NotificationPopupProps> = (props) => {
     },
     renderers: {
       notification: props.renderers?.notification
+    },
+    popoverPosition: {
+      anchorOrigin: {
+        vertical: props.popoverPosition?.anchorOrigin?.vertical ?? 'top',
+        horizontal: props.popoverPosition?.anchorOrigin?.horizontal ?? 'left'
+      }
     }
   };
 
@@ -111,12 +123,14 @@ export const NotificationPopup: React.FC<NotificationPopupProps> = (props) => {
           }
         }}
         aria-hidden={!anchorEl}
+        anchorOrigin={config.popoverPosition.anchorOrigin}
       >
         <div
           style={{
             width: config.popupWidth,
             padding: '0 16px',
-            zIndex: props.popupZIndex
+            zIndex: props.popupZIndex,
+            height: config.popupHeight
           }}
         >
           <Inbox

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@notificationapi/react",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@notificationapi/react",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@notificationapi/react",
   "private": false,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
Added popoverPosition object for the notification popup to allow users the ability to move the popver feed away from the button, fixed the pagePosition to work to allow the user to set the pagination buttons either top or bottom